### PR TITLE
Issue #5

### DIFF
--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -55,9 +55,9 @@ var downloadFiles = function* (taskInfo, { dryRun, print = _.noop, outputDir, do
     }
 
     //var { status } = subprocess.spawnSync('sh', ['-c', downloadCommand], {
-      //stdio: 'inherit'
+    //stdio: 'inherit'
     //});
-	var { status } = subprocess.spawnSync(`aria2c`, aria2cOptions, { stdio: 'inherit', shell: true });
+    var { status } = subprocess.spawnSync('aria2c', aria2cOptions, { stdio: 'inherit', shell: true });
 
     process.stderr.write('\33[2K\r');
 

--- a/lib/downloader.js
+++ b/lib/downloader.js
@@ -43,7 +43,8 @@ var downloadFiles = function* (taskInfo, { dryRun, print = _.noop, outputDir, do
         `--dir="${outputDir}"`,
         `--out="${fileName}"`,
         `--referer="${taskInfo.url}"`,
-        ...downloadOptions.map((option) => (option.length === 1 || option.indexOf('=') === 1) ? `-${option}` : `--${option}`)
+        ...downloadOptions.map((option) => (option.length === 1 || option.indexOf('=') === 1) ? `-${option}` : `--${option}`),
+        `"${url}"`
       ]
       , downloadCommand = `aria2c ${aria2cOptions.join(' ')} "${url}"`;
 
@@ -53,9 +54,10 @@ var downloadFiles = function* (taskInfo, { dryRun, print = _.noop, outputDir, do
       return filePath;
     }
 
-    var { status } = subprocess.spawnSync('sh', ['-c', downloadCommand], {
-      stdio: 'inherit'
-    });
+    //var { status } = subprocess.spawnSync('sh', ['-c', downloadCommand], {
+      //stdio: 'inherit'
+    //});
+	var { status } = subprocess.spawnSync(`aria2c`, aria2cOptions, { stdio: 'inherit', shell: true });
 
     process.stderr.write('\33[2K\r');
 

--- a/lib/merger.js
+++ b/lib/merger.js
@@ -16,7 +16,8 @@ var mergeSegmentFiles = function* (segmentFiles, outputPath, { dryRun }) {
       '-f concat',
       '-safe 0',
       `-i "${tmpFile.path}"`,
-      '-c copy'
+      '-c copy',
+      `"${path.resolve(outputPath)}"`
     ]
     , mergeCommand = `ffmpeg ${ffmpegOptions.join(' ')} "${path.resolve(outputPath)}"`;
 
@@ -26,9 +27,10 @@ var mergeSegmentFiles = function* (segmentFiles, outputPath, { dryRun }) {
     return;
   }
 
-  var { status } = subprocess.spawnSync('sh', ['-c', mergeCommand], {
-    stdio: 'inherit'
-  });
+  //var { status } = subprocess.spawnSync('sh', ['-c', mergeCommand], {
+    //stdio: 'inherit'
+  //});
+  var { status } = subprocess.spawnSync(`ffmpeg`, ffmpegOptions, { stdio: 'inherit', shell: true });
 
   if (status) {
     if (yield fs.exists(outputPath)) {

--- a/lib/merger.js
+++ b/lib/merger.js
@@ -28,9 +28,9 @@ var mergeSegmentFiles = function* (segmentFiles, outputPath, { dryRun }) {
   }
 
   //var { status } = subprocess.spawnSync('sh', ['-c', mergeCommand], {
-    //stdio: 'inherit'
+  //stdio: 'inherit'
   //});
-  var { status } = subprocess.spawnSync(`ffmpeg`, ffmpegOptions, { stdio: 'inherit', shell: true });
+  var { status } = subprocess.spawnSync('ffmpeg', ffmpegOptions, { stdio: 'inherit', shell: true });
 
   if (status) {
     if (yield fs.exists(outputPath)) {


### PR DESCRIPTION
Changed a way to spawn subprocess for windows system.
This only tested on windows 10. node version 8.11.1
May need to brush up more such as `downloadCommand` or `mergeCommand`.